### PR TITLE
Fix crash in destructor

### DIFF
--- a/src/raw-io-handler.cpp
+++ b/src/raw-io-handler.cpp
@@ -31,6 +31,7 @@ class RawIOHandlerPrivate
 public:
     RawIOHandlerPrivate(RawIOHandler *qq):
         raw(0),
+        stream(0),
         q(qq)
     {}
 


### PR DESCRIPTION
Pointer was uninitialized, causing crash while deleting it.
