### PR TITLE
Install .desktop file for KDE

### DIFF
--- a/common-config.pri
+++ b/common-config.pri
@@ -30,3 +30,16 @@ isEmpty(LIBDIR) {
     message("====")
     message("==== library install path set to `$${INSTALL_LIBDIR}'")
 }
+
+
+INSTALL_KDEDIR = $${PREFIX}
+
+isEmpty(KDEDIR) {
+    message("====")
+    message("==== NOTE: To override the KDE installation path run: `qmake KDEDIR=/custom/path'")
+    message("==== (current installation path is `$${INSTALL_KDEDIR}')")
+} else {
+    INSTALL_KDEDIR = $${KDEDIR}
+    message("====")
+    message("==== KDE install path set to `$${INSTALL_KDEDIR}'")
+}

--- a/src/raw.desktop
+++ b/src/raw.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Service
+X-KDE-ServiceTypes=QImageIOPlugins
+X-KDE-ImageFormat=raw
+X-KDE-MimeType=image/x-sony-arw
+X-KDE-Read=true
+X-KDE-Write=false

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,3 +1,5 @@
+include(../common-config.pri)
+
 TARGET  = qtraw
 TEMPLATE = lib
 CONFIG += \
@@ -18,3 +20,8 @@ SOURCES += \
 
 target.path += $$[QT_INSTALL_PLUGINS]/imageformats
 INSTALLS += target
+
+# For KDE, install a .desktop file with metadata about the loader
+kde_desktop.files = raw.desktop
+kde_desktop.path = $${INSTALL_KDEDIR}/share/kde4/services/qimageioplugins/
+INSTALLS += kde_desktop


### PR DESCRIPTION
Install a .desktop file so that KDE can associate the plugin with mimetypes.

Note: I only added the arw mimetype for now as I don't know the mimetypes for the others. This list must be extended to support the other formats.
